### PR TITLE
dag-json implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 .gdb_history
 Cargo.lock
+target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
     "dag-cbor",
+    "dag-json",
     "core"
 ]

--- a/dag-json/Cargo.toml
+++ b/dag-json/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ipld-dag-json"
+version = "0.1.0"
+authors = ["Irakli Gozalishvili <contact@gozala.io>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+ipld-core = { path = "../core" }
+serde_json = "1.0"
+serde = { version = "1.0.101", features = ["derive"] }
+base64 = "0.11.0"

--- a/dag-json/LICENSE-APACHE
+++ b/dag-json/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/dag-json/LICENSE-MIT
+++ b/dag-json/LICENSE-MIT
@@ -1,0 +1,25 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/dag-json/src/lib.rs
+++ b/dag-json/src/lib.rs
@@ -1,18 +1,28 @@
 use base64;
 use ipld_core::Ipld;
-use serde::ser::{self, Serialize};
-use serde_json;
+use serde::{de, ser, Deserialize, Serialize};
+use serde_json::ser::Serializer;
+use serde_json::Error;
 use std::collections::BTreeMap;
+use std::fmt;
+use std::iter::FromIterator;
+
+const LINK_KEY: &str = "/";
 
 pub enum EncodeError {
     Error,
 }
 
-pub fn encode(ipld: &Ipld) -> Result<Vec<u8>, serde_json::Error> {
+pub fn encode(ipld: &Ipld) -> Result<Vec<u8>, Error> {
     let mut writer = Vec::with_capacity(128);
-    let mut ser = serde_json::ser::Serializer::new(&mut writer);
+    let mut ser = Serializer::new(&mut writer);
     serialize(&ipld, &mut ser)?;
     Ok(writer)
+}
+
+pub fn decode(data: &[u8]) -> Result<Ipld, Error> {
+    let mut de = serde_json::Deserializer::from_slice(&data);
+    deserialize(&mut de)
 }
 
 fn serialize<S>(ipld: &Ipld, ser: S) -> Result<S::Ok, S::Error>
@@ -44,7 +54,14 @@ where
     }
 }
 
-// Needed for `collect_seq` and `collect_map` in Deserializer
+fn deserialize<'de, D>(deserializer: D) -> Result<Ipld, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    deserializer.deserialize_any(JSONVisitor)
+}
+
+// Needed for `collect_seq` and `collect_map` in Seserializer
 struct Wrapper<'a>(&'a Ipld);
 impl<'a> Serialize for Wrapper<'a> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -52,5 +69,168 @@ impl<'a> Serialize for Wrapper<'a> {
         S: ser::Serializer,
     {
         serialize(&self.0, serializer)
+    }
+}
+
+// serde deserializer visitor that is used by Deseraliazer to decode
+// json into IPLD.
+struct JSONVisitor;
+impl<'de> de::Visitor<'de> for JSONVisitor {
+    type Value = Ipld;
+
+    fn expecting(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str("any valid JSON value")
+    }
+
+    #[inline]
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.visit_string(String::from(value))
+    }
+
+    #[inline]
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Ipld::String(value))
+    }
+    #[inline]
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.visit_byte_buf(v.to_owned())
+    }
+
+    #[inline]
+    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Ipld::Bytes(v))
+    }
+
+    #[inline]
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Ipld::Integer(v.into()))
+    }
+
+    #[inline]
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Ipld::Integer(v.into()))
+    }
+
+    #[inline]
+    fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Ipld::Integer(v))
+    }
+
+    #[inline]
+    fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Ipld::Bool(v))
+    }
+
+    #[inline]
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.visit_unit()
+    }
+
+    #[inline]
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Ipld::Null)
+    }
+
+    #[inline]
+    fn visit_seq<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+    where
+        V: de::SeqAccess<'de>,
+    {
+        let mut vec: Vec<WrapperOwned> = Vec::new();
+
+        while let Some(elem) = visitor.next_element()? {
+            vec.push(elem);
+        }
+
+        let unwrapped = vec.into_iter().map(|WrapperOwned(ipld)| ipld).collect();
+        Ok(Ipld::List(unwrapped))
+    }
+
+    #[inline]
+    fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+    where
+        V: de::MapAccess<'de>,
+    {
+        let mut values: Vec<(String, WrapperOwned)> = Vec::new();
+
+        while let Some((key, value)) = visitor.next_entry()? {
+            values.push((key, value));
+        }
+
+        // JSON Object represents IPLD Link if it is `{ "/": "...." }` therefor
+        // we valiadet if that is the case here.
+        if let Some((key, WrapperOwned(Ipld::String(value)))) = values.first() {
+            if key == LINK_KEY && values.len() == 1 {
+                let link = base64::decode(value);
+                // TODO: Find out what is the expected behavior in cases where
+                // value is not a valid CID (or base64 endode string here). For
+                // now treat it as some other JSON Object.
+                if let Ok(bytes) = link {
+                    return Ok(Ipld::Link(bytes));
+                }
+            }
+        }
+
+        let unwrapped = values
+            .into_iter()
+            .map(|(key, WrapperOwned(value))| (key, value));
+        Ok(Ipld::Map(BTreeMap::from_iter(unwrapped)))
+    }
+
+    #[inline]
+    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Ipld::Float(v))
+    }
+}
+
+// Needed for `visit_seq` and `visit_map` in Deserializer
+/// We cannot directly implement `serde::Deserializer` for `Ipld` as it is a remote type.
+/// Instead wrap it into a newtype struct and implement `serde::Deserialize` for that one.
+/// All the deserializer does is calling the `deserialize()` function we defined which returns
+/// an unwrapped `Ipld` instance. Wrap that `Ipld` instance in `Wrapper` and return it.
+/// Users of this wrapper will then unwrap it again so that they can return the expected `Ipld`
+/// instance.
+struct WrapperOwned(Ipld);
+impl<'de> Deserialize<'de> for WrapperOwned {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let deserialized = deserialize(deserializer);
+        // Better version of Ok(Wrapper(deserialized.unwrap()))
+        deserialized.map(Self)
     }
 }

--- a/dag-json/src/lib.rs
+++ b/dag-json/src/lib.rs
@@ -1,0 +1,56 @@
+use base64;
+use ipld_core::Ipld;
+use serde::ser::{self, Serialize};
+use serde_json;
+use std::collections::BTreeMap;
+
+pub enum EncodeError {
+    Error,
+}
+
+pub fn encode(ipld: &Ipld) -> Result<Vec<u8>, serde_json::Error> {
+    let mut writer = Vec::with_capacity(128);
+    let mut ser = serde_json::ser::Serializer::new(&mut writer);
+    serialize(&ipld, &mut ser)?;
+    Ok(writer)
+}
+
+fn serialize<S>(ipld: &Ipld, ser: S) -> Result<S::Ok, S::Error>
+where
+    S: ser::Serializer,
+{
+    match &ipld {
+        Ipld::Null => ser.serialize_none(),
+        Ipld::Bool(bool) => ser.serialize_bool(*bool),
+        Ipld::Integer(i128) => ser.serialize_i128(*i128),
+        Ipld::Float(f64) => ser.serialize_f64(*f64),
+        Ipld::String(string) => ser.serialize_str(&string),
+        Ipld::Bytes(bytes) => ser.serialize_bytes(&bytes),
+        Ipld::List(list) => {
+            let wrapped = list.iter().map(|ipld| Wrapper(ipld));
+            ser.collect_seq(wrapped)
+        }
+        Ipld::Map(map) => {
+            let wrapped = map.iter().map(|(key, ipld)| (key, Wrapper(ipld)));
+            ser.collect_map(wrapped)
+        }
+        Ipld::Link(link) => {
+            let value = base64::encode(&link);
+            let mut map = BTreeMap::new();
+            map.insert("/", value);
+
+            ser.collect_map(map)
+        }
+    }
+}
+
+// Needed for `collect_seq` and `collect_map` in Deserializer
+struct Wrapper<'a>(&'a Ipld);
+impl<'a> Serialize for Wrapper<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        serialize(&self.0, serializer)
+    }
+}

--- a/dag-json/tests/test.rs
+++ b/dag-json/tests/test.rs
@@ -1,0 +1,29 @@
+use std::collections::BTreeMap;
+
+use ipld_core::Ipld;
+use ipld_dag_json;
+
+#[test]
+fn encode_struct() {
+  // Create a contact object that looks like:
+  // Contact { name: "Hello World", details: CID }
+  let mut map = BTreeMap::new();
+  map.insert("name".to_string(), Ipld::String("Hello World!".to_string()));
+  map.insert("details".to_string(), Ipld::Link(vec![7, 8, 9]));
+  let contact = Ipld::Map(map);
+
+  let contact_encoded = ipld_dag_json::encode(&contact).unwrap();
+  println!("encoded: {:02x?}", contact_encoded);
+  println!(
+    "encoded string {}",
+    std::str::from_utf8(&contact_encoded).unwrap()
+  );
+
+  assert_eq!(
+    std::str::from_utf8(&contact_encoded).unwrap(),
+    r#"{"details":{"/":"BwgJ"},"name":"Hello World!"}"#
+  );
+
+  // let contact_decoded: Ipld = ipld_dag_json::decode(&contact_encoded).unwrap();
+  // assert_eq!(contact_decoded, contact);
+}

--- a/dag-json/tests/test.rs
+++ b/dag-json/tests/test.rs
@@ -24,6 +24,6 @@ fn encode_struct() {
     r#"{"details":{"/":"BwgJ"},"name":"Hello World!"}"#
   );
 
-  // let contact_decoded: Ipld = ipld_dag_json::decode(&contact_encoded).unwrap();
-  // assert_eq!(contact_decoded, contact);
+  let contact_decoded: Ipld = ipld_dag_json::decode(&contact_encoded).unwrap();
+  assert_eq!(contact_decoded, contact);
 }


### PR DESCRIPTION
Draft implementation of #1

Current implementation does use https://github.com/serde-rs/json to avoid recreating JSON parser / serializer. That being said, implementation could be updated to remove serde dependency of so desired.